### PR TITLE
Fix broken link

### DIFF
--- a/index.html
+++ b/index.html
@@ -300,7 +300,7 @@
 	<td>Sep. 22nd</td>
 	<td>Lecture 2:  Language models and beyond</td>
 	<td>
-		<a href="A Neural Probabilistic Language Model">A Neural Probabilistic Language Model</a><br>
+		<a href="https://dl.acm.org/doi/10.5555/944919.944966">A Neural Probabilistic Language Model</a><br>
 		<a href="https://arxiv.org/abs/1810.04805">BERT: Pre-training of Deep Bidirectional Transformers for Language Understanding</a><br>
 		<a href="https://arxiv.org/abs/2203.02155">Training language models to follow instructions with human feedback</a>
 	</td>


### PR DESCRIPTION
The recommended reading of lecture 2 has a broken link.
I guess it should be [Yoshua Bengio, Réjean Ducharme, Pascal Vincent, and Christian Janvin. 2003. A neural probabilistic language model. J. Mach. Learn. Res. 3](https://dl.acm.org/doi/10.5555/944919.944966)



